### PR TITLE
Add natural language query endpoint

### DIFF
--- a/src/Cdr.Api/Endpoints/CdrEndpoints.cs
+++ b/src/Cdr.Api/Endpoints/CdrEndpoints.cs
@@ -1,5 +1,6 @@
 using Cdr.Application.Anomalies;
 using Cdr.Application.Ingestion;
+using Cdr.Application.Nl;
 using Cdr.Contracts.Dtos;
 
 namespace Cdr.Api.Endpoints;
@@ -46,6 +47,14 @@ public static class CdrEndpoints
             return Results.Ok(res);
         })
         .WithSummary("Detect anomalies");
+
+        grp.MapGet("/query", async (string q, NlQueryHandler handler, CancellationToken ct) =>
+        {
+            var res = await handler.HandleAsync(q, ct);
+            return Results.Ok(res);
+        })
+        .WithSummary("Natural language query")
+        .Produces<NlQueryResponse>();
 
         return app;
     }

--- a/src/Cdr.Api/Program.cs
+++ b/src/Cdr.Api/Program.cs
@@ -39,6 +39,7 @@ builder.Services.AddHealthChecks()
 // Add Application Services
 builder.Services.AddScoped<UploadCdrCsvHandler>();
 builder.Services.AddScoped<Cdr.Application.Anomalies.DetectAnomaliesHandler>();
+builder.Services.AddScoped<Cdr.Application.Nl.NlQueryHandler>();
 
 var app = builder.Build();
 
@@ -65,15 +66,17 @@ app.MapCdrEndpoints();
 using (var scope = app.Services.CreateScope())
 {
     var context = scope.ServiceProvider.GetRequiredService<Cdr.Infrastructure.Persistence.CdrDbContext>();
-    try
+    if (context.Database.IsRelational())
     {
-        await context.Database.MigrateAsync();
-    }
-    catch (Exception ex)
-    {
-        // Log the error but don't fail the startup
-        var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
-        logger.LogWarning(ex, "Failed to apply database migrations. The application will continue but may not function correctly.");
+        try
+        {
+            await context.Database.MigrateAsync();
+        }
+        catch (Exception ex)
+        {
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+            logger.LogWarning(ex, "Failed to apply database migrations. The application will continue but may not function correctly.");
+        }
     }
 }
 

--- a/src/Cdr.Application/Abstractions/ICdrRepository.cs
+++ b/src/Cdr.Application/Abstractions/ICdrRepository.cs
@@ -8,4 +8,6 @@ public interface ICdrRepository
     Task<bool> ExistsByReferenceAsync(string reference, CancellationToken ct);
     Task AddRangeAsync(IEnumerable<CdrRecord> records, CancellationToken ct);
     IAsyncEnumerable<CdrRecord> QueryAsync(CdrSpecification spec, CancellationToken ct);
+    Task<int> CountAsync(CdrSpecification spec, CancellationToken ct);
+    Task<decimal> SumCostAsync(CdrSpecification spec, CancellationToken ct);
 }

--- a/src/Cdr.Application/Nl/NlQueryHandler.cs
+++ b/src/Cdr.Application/Nl/NlQueryHandler.cs
@@ -1,0 +1,53 @@
+using Cdr.Application.Abstractions;
+using Cdr.Contracts.Dtos;
+using Cdr.Domain.Specifications;
+
+namespace Cdr.Application.Nl;
+
+public sealed class NlQueryHandler
+{
+    private readonly ICdrRepository _repo;
+    public NlQueryHandler(ICdrRepository repo) => _repo = repo;
+
+    public async Task<NlQueryResponse> HandleAsync(string query, CancellationToken ct)
+    {
+        var parsed = NlQueryParser.Parse(query);
+        var spec = new CdrSpecification();
+
+        if (parsed.Filters.TryGetValue("callerId", out var caller))
+            spec = spec with { CallerId = caller };
+        if (parsed.Filters.TryGetValue("recipientCountry", out var country) && country == "USA")
+            spec = spec with { RecipientStartsWith = "+1" };
+        if (parsed.Filters.TryGetValue("range", out var range))
+        {
+            if (range == "last_week")
+            {
+                var end = DateOnly.FromDateTime(DateTime.UtcNow);
+                var start = end.AddDays(-7);
+                spec = spec with { From = start, To = end };
+            }
+            else if (range == "june")
+            {
+                var year = DateTime.UtcNow.Year;
+                var start = new DateOnly(year, 6, 1);
+                var end = start.AddMonths(1).AddDays(-1);
+                spec = spec with { From = start, To = end };
+            }
+        }
+
+        if (parsed.Intent == "count_calls")
+        {
+            var count = await _repo.CountAsync(spec, ct);
+            var res = new Dictionary<string, object> { ["count"] = count };
+            return new NlQueryResponse(parsed.Intent, parsed.Filters, res);
+        }
+        if (parsed.Intent == "total_cost")
+        {
+            var total = await _repo.SumCostAsync(spec, ct);
+            var res = new Dictionary<string, object> { ["totalCost"] = total };
+            return new NlQueryResponse(parsed.Intent, parsed.Filters, res);
+        }
+
+        return parsed;
+    }
+}

--- a/src/Cdr.Application/Nl/NlQueryParser.cs
+++ b/src/Cdr.Application/Nl/NlQueryParser.cs
@@ -12,13 +12,17 @@ public static class NlQueryParser
         var filters = new Dictionary<string, string>();
         if (Regex.IsMatch(q, "how many|count"))
         {
-            // naive phone extraction
             var m = Regex.Match(q, @"(\+?\d[\d\s]{5,})");
             var phone = m.Success ? m.Groups[1].Value.Replace(" ", "") : string.Empty;
             if (!string.IsNullOrEmpty(phone)) filters["callerId"] = phone;
-            // naive "last week" handling
             if (q.Contains("last week")) filters["range"] = "last_week";
             return new NlQueryResponse("count_calls", filters, new Dictionary<string, object>());
+        }
+        if (Regex.IsMatch(q, "total.*cost"))
+        {
+            if (q.Contains("usa")) filters["recipientCountry"] = "USA";
+            if (q.Contains("in june")) filters["range"] = "june";
+            return new NlQueryResponse("total_cost", filters, new Dictionary<string, object>());
         }
         return new NlQueryResponse("unknown", filters, new Dictionary<string, object>());
     }

--- a/src/Cdr.Domain/Specifications/CdrSpecification.cs
+++ b/src/Cdr.Domain/Specifications/CdrSpecification.cs
@@ -6,4 +6,5 @@ public sealed class CdrSpecification
     public DateOnly? To { get; init; }
     public string? CallerId { get; init; }
     public string? Recipient { get; init; }
+    public string? RecipientStartsWith { get; init; }
 }

--- a/src/Cdr.Infrastructure/Persistence/Repositories/CdrRepository.cs
+++ b/src/Cdr.Infrastructure/Persistence/Repositories/CdrRepository.cs
@@ -21,11 +21,24 @@ public sealed class CdrRepository : ICdrRepository
 
     public async IAsyncEnumerable<CdrRecord> QueryAsync(CdrSpecification spec, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
     {
+        var q = Apply(spec);
+        await foreach (var item in q.AsAsyncEnumerable().WithCancellation(ct)) yield return item;
+    }
+
+    public Task<int> CountAsync(CdrSpecification spec, CancellationToken ct)
+        => Apply(spec).CountAsync(ct);
+
+    public Task<decimal> SumCostAsync(CdrSpecification spec, CancellationToken ct)
+        => Apply(spec).SumAsync(x => x.Cost, ct);
+
+    private IQueryable<CdrRecord> Apply(CdrSpecification spec)
+    {
         var q = _db.CdrRecords.AsNoTracking().AsQueryable();
         if (spec.From.HasValue) q = q.Where(x => x.CallDate >= spec.From.Value);
         if (spec.To.HasValue) q = q.Where(x => x.CallDate <= spec.To.Value);
         if (!string.IsNullOrWhiteSpace(spec.CallerId)) q = q.Where(x => x.CallerId == spec.CallerId);
         if (!string.IsNullOrWhiteSpace(spec.Recipient)) q = q.Where(x => x.Recipient == spec.Recipient);
-        await foreach (var item in q.AsAsyncEnumerable().WithCancellation(ct)) yield return item;
+        if (!string.IsNullOrWhiteSpace(spec.RecipientStartsWith)) q = q.Where(x => x.Recipient.StartsWith(spec.RecipientStartsWith));
+        return q;
     }
 }

--- a/tests/Cdr.IntegrationTests/Api/QueryEndpointTests.cs
+++ b/tests/Cdr.IntegrationTests/Api/QueryEndpointTests.cs
@@ -1,0 +1,21 @@
+using Cdr.Contracts.Dtos;
+using Cdr.IntegrationTests.TestHost;
+using FluentAssertions;
+using System.Net.Http.Json;
+
+namespace Cdr.IntegrationTests.Api;
+
+public class QueryEndpointTests : IClassFixture<IntegrationWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    public QueryEndpointTests(IntegrationWebApplicationFactory f) { _client = f.CreateClient(); }
+
+    [Fact]
+    public async Task Query_Returns_Ok()
+    {
+        var resp = await _client.GetAsync("/api/cdr/query?q=How%20many%20calls%20did%2001482%20123456%20make%20last%20week?");
+        resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        var dto = await resp.Content.ReadFromJsonAsync<NlQueryResponse>();
+        dto!.Intent.Should().Be("count_calls");
+    }
+}

--- a/tests/Cdr.IntegrationTests/TestHost/IntegrationWebApplicationFactory.cs
+++ b/tests/Cdr.IntegrationTests/TestHost/IntegrationWebApplicationFactory.cs
@@ -1,5 +1,20 @@
+using Cdr.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
 
 namespace Cdr.IntegrationTests.TestHost;
 
-public class IntegrationWebApplicationFactory : WebApplicationFactory<Program> { }
+public class IntegrationWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<CdrDbContext>));
+            if (descriptor != null) services.Remove(descriptor);
+            services.AddDbContext<CdrDbContext>(o => o.UseInMemoryDatabase("test_db"));
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- extend repository and spec to support counting and cost aggregation
- implement simple natural language query parser and handler
- expose `/api/cdr/query` endpoint and add in-memory test infrastructure

## Testing
- ⚠️ `dotnet test` *(command failed: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a27fc3b748832a820f09db96ffc0a7